### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#BackCMS (初心)
+# BackCMS (初心)
 
 基于 Laravel 的CMS,功能非常简洁.
 
@@ -10,7 +10,7 @@
 * 系统文件组件 (项目文件增删改查)
 * 多语言支持 (支持后台yaml配置语言文件,路由自动识别切换)
 
-##安装方式
+## 安装方式
 * 下载文件
 * composer update
 * cp .env.example .env && ./artisan key:generate
@@ -19,12 +19,12 @@
 * 安装成功后,会在 /storage/app 生成 installed 文件
 
 
-##卸载数据
+## 卸载数据
 * 访问 /storage/app 下 installed 文件 ,里面有卸载密码.
 * 访问 http://xxxxx/install/uninstall/卸载密码
 * 卸载成功
 
-##如果还有问题...
+## 如果还有问题...
 
 如果还有问题,就我擦了
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
